### PR TITLE
Add equipment slots, equip-aware inventory UI, and finale scene

### DIFF
--- a/InventorySystem/Tooltip.tscn
+++ b/InventorySystem/Tooltip.tscn
@@ -32,6 +32,10 @@ func show_tooltip(item: InvItem, position: Vector2):
 		if item.drop_chance > 0:
 			var drop_chance_percent = item.drop_chance * 100
 			stats_text += \"[img=16]res://InventorySystem/Icons/drop_chance_icon.png[/img] [color=#4ECB71]\" + str(drop_chance_percent) + \"%[/color] Drop Chance\\n\"
+
+		# Ausrüstungsslot anzeigen
+		if item.is_equipment and item.equip_slot != \"\":
+			stats_text += \"[color=#FFD166]Ausrüstung: \" + item.equip_slot.capitalize() + \"[/color]\\n\"
 		
 		# Gesundheit
 		if item.health_bonus != 0:

--- a/InventorySystem/inv_ui.gd
+++ b/InventorySystem/inv_ui.gd
@@ -1,23 +1,35 @@
 extends Control
 
 @onready var inv: Inv = preload("res://InventorySystem/playerinv.tres")
-@onready var slots: Array = $NinePatchRect/GridContainer.get_children()
+@onready var inventory_slot_nodes: Array = $NinePatchRect/GridContainer.get_children()
+@onready var equipment_slot_nodes: Array = _get_equipment_slot_nodes()
 @onready var spind_ui = $SpindUI
 @onready var tooltip = preload("res://InventorySystem/Tooltip.tscn").instantiate()
 
 var is_open = false
 var dragging_item = null
 var dragging_sprite = null
-var dragging_slot_index = -1
+var dragging_slot_ref_index = -1
 var detected_slot_index = -1
 var dragging_item_scale = 0.5
 var hovered_slot_index = -1
 var is_hovering = false
+var slot_refs: Array = []
+
+const EQUIPMENT_SLOT_TYPES = {
+	"WeaponSlot": "weapon",
+	"HeadSlot": "head",
+	"ChestSlot": "chest",
+	"BootsSlot": "boots",
+	"RingSlot": "ring",
+	"AmuletSlot": "amulet"
+}
 
 var save_path = "user://inventory.save"
 
 func _ready() -> void:
 	inv.update.connect(update_slots)
+	_build_slot_refs()
 	update_slots()
 	inv.load_inventory(save_path)
 	close()
@@ -25,6 +37,119 @@ func _ready() -> void:
 	# Tooltip als Child hinzufügen
 	add_child(tooltip)
 	tooltip.visible = false
+
+func _get_equipment_slot_nodes() -> Array:
+	if has_node("EquipmentPanel/EquipmentGrid"):
+		var nodes = []
+		for node in $EquipmentPanel/EquipmentGrid.get_children():
+			if node is Panel:
+				nodes.append(node)
+		return nodes
+	return []
+
+func _build_slot_refs() -> void:
+	slot_refs.clear()
+	for i in range(inventory_slot_nodes.size()):
+		slot_refs.append({
+			"kind": "inventory",
+			"index": i,
+			"node": inventory_slot_nodes[i],
+			"equip_type": ""
+		})
+	for i in range(equipment_slot_nodes.size()):
+		var slot_node = equipment_slot_nodes[i]
+		slot_refs.append({
+			"kind": "equipment",
+			"index": i,
+			"node": slot_node,
+			"equip_type": EQUIPMENT_SLOT_TYPES.get(slot_node.name, "")
+		})
+
+func _get_slot_ref(index: int) -> Dictionary:
+	if index < 0 or index >= slot_refs.size():
+		return {}
+	return slot_refs[index]
+
+func _get_slot_data(slot_ref: Dictionary) -> InvSlot:
+	if slot_ref.get("kind") == "equipment":
+		var equip_index = slot_ref.get("index", -1)
+		if equip_index >= 0 and equip_index < inv.equipment_slots.size():
+			return inv.equipment_slots[equip_index]
+		return null
+	var inv_index = slot_ref.get("index", -1)
+	if inv_index >= 0 and inv_index < inv.slots.size():
+		return inv.slots[inv_index]
+	return null
+
+func _is_equipment_slot(slot_ref: Dictionary) -> bool:
+	return slot_ref.get("kind") == "equipment"
+
+func _can_place_in_equipment(slot_ref: Dictionary, item: InvItem) -> bool:
+	if item == null:
+		return false
+	var expected_slot = slot_ref.get("equip_type", "")
+	if not item.is_equipment:
+		return false
+	if expected_slot == "":
+		return false
+	return item.equip_slot == expected_slot
+
+func _handle_inventory_drop(source_slot: InvSlot, target_slot: InvSlot) -> void:
+	if target_slot.item == source_slot.item and target_slot.amount < 64:
+		var remaining_space = 64 - target_slot.amount
+		var amount_to_stack = min(remaining_space, source_slot.amount)
+		target_slot.amount += amount_to_stack
+		source_slot.amount -= amount_to_stack
+		if source_slot.amount == 0:
+			source_slot.item = null
+	else:
+		_swap_slot_contents(source_slot, target_slot)
+
+func _handle_drop_to_equipment(source_ref: Dictionary, target_ref: Dictionary, source_slot: InvSlot, target_slot: InvSlot) -> void:
+	if not _can_place_in_equipment(target_ref, source_slot.item):
+		return
+
+	if source_slot.amount > 1:
+		if target_slot.item == null:
+			target_slot.item = source_slot.item
+			target_slot.amount = 1
+			source_slot.amount -= 1
+			if source_slot.amount == 0:
+				source_slot.item = null
+		return
+
+	if target_slot.item == null:
+		target_slot.item = source_slot.item
+		target_slot.amount = 1
+		source_slot.item = null
+		source_slot.amount = 0
+		return
+
+	if _is_equipment_slot(source_ref) and not _can_place_in_equipment(source_ref, target_slot.item):
+		return
+
+	_swap_slot_contents(source_slot, target_slot)
+	target_slot.amount = 1
+	if _is_equipment_slot(source_ref):
+		source_slot.amount = 1
+
+func _handle_drop_from_equipment(source_ref: Dictionary, target_ref: Dictionary, source_slot: InvSlot, target_slot: InvSlot) -> void:
+	if target_slot.item == source_slot.item and target_slot.amount < 64:
+		target_slot.amount += 1
+		source_slot.item = null
+		source_slot.amount = 0
+	else:
+		_swap_slot_contents(source_slot, target_slot)
+		if _is_equipment_slot(source_ref):
+			source_slot.amount = min(source_slot.amount, 1)
+
+func _swap_slot_contents(slot_a: InvSlot, slot_b: InvSlot) -> void:
+	var temp_item = slot_a.item
+	var temp_amount = slot_a.amount
+	slot_a.item = slot_b.item
+	slot_a.amount = slot_b.amount
+	slot_b.item = temp_item
+	slot_b.amount = temp_amount
 
 func _process(delta: float) -> void:
 	if Input.is_action_just_pressed("inventory"):
@@ -60,7 +185,8 @@ func _process(delta: float) -> void:
 
 func _update_tooltip():
 	if hovered_slot_index != -1 and is_open:
-		var slot = inv.slots[hovered_slot_index]
+		var slot_ref = _get_slot_ref(hovered_slot_index)
+		var slot = _get_slot_data(slot_ref)
 		if slot and slot.item:
 			await get_tree().create_timer(0.3).timeout
 			if hovered_slot_index != -1 and is_open:
@@ -82,44 +208,53 @@ func close():
 	tooltip.hide_tooltip()
 	
 	if dragging_item:
-		var source_slot = inv.slots[dragging_slot_index]
-		if source_slot:
-			var item_display = slots[dragging_slot_index].get_node("CenterContainer/Panel/ItemDisplay") if slots[dragging_slot_index].has_node("CenterContainer/Panel/ItemDisplay") else null
-			if item_display:
-				item_display.visible = true
+		var source_slot_ref = _get_slot_ref(dragging_slot_ref_index)
+		if source_slot_ref:
+			var source_slot = _get_slot_data(source_slot_ref)
+			if source_slot:
+				var source_node = source_slot_ref["node"]
+				var item_display = source_node.get_node("CenterContainer/Panel/ItemDisplay") if source_node.has_node("CenterContainer/Panel/ItemDisplay") else null
+				if item_display:
+					item_display.visible = true
 
 		dragging_item.queue_free()
 		dragging_item = null
 		dragging_sprite = null
-		dragging_slot_index = -1
+		dragging_slot_ref_index = -1
 		update_slots()
 
 func update_slots():
-	for i in range(min(inv.slots.size(), slots.size())):
-		var slot = slots[i]
-		var item_display = slot.get_node("CenterContainer/Panel/ItemDisplay") if slot.has_node("CenterContainer/Panel/ItemDisplay") else null
+	for i in range(slot_refs.size()):
+		var slot_ref = slot_refs[i]
+		var slot_node = slot_ref["node"]
+		var slot_data = _get_slot_data(slot_ref)
+		if slot_data == null:
+			continue
+
+		var item_display = slot_node.get_node("CenterContainer/Panel/ItemDisplay") if slot_node.has_node("CenterContainer/Panel/ItemDisplay") else null
 
 		# Verstecke das Item im ursprünglichen Slot, wenn es gezogen wird
-		if i == dragging_slot_index and dragging_item:
+		if i == dragging_slot_ref_index and dragging_item:
 			if item_display:
-				item_display.visible = false  # Verstecke das Item im Slot
+				item_display.visible = false
 		else:
-			# Zeige das Item an, wenn es im Slot vorhanden ist
 			if item_display:
-				item_display.visible = inv.slots[i].item != null
+				item_display.visible = slot_data.item != null
 
 		# Aktualisiere den Slot, wenn es nicht der gezogene Slot ist
-		if i != dragging_slot_index:
-			slot.update(inv.slots[i])
+		if i != dragging_slot_ref_index:
+			slot_node.update(slot_data)
 			
 func _on_slot_pressed(slot_index: int):
 	if !is_open:  # Prüfe, ob das Inventar geschlossen ist
 		return
 	if slot_index != -1:
-		var slot = inv.slots[slot_index]
+		var slot_ref = _get_slot_ref(slot_index)
+		var slot = _get_slot_data(slot_ref)
 		if slot.item:
 			# Verstecke das ItemDisplay (Sprite2D) im Slot sofort
-			var item_display = slots[slot_index].get_node("CenterContainer/Panel/ItemDisplay") if slots[slot_index].has_node("CenterContainer/Panel/ItemDisplay") else null
+			var slot_node = slot_ref.get("node")
+			var item_display = slot_node.get_node("CenterContainer/Panel/ItemDisplay") if slot_node and slot_node.has_node("CenterContainer/Panel/ItemDisplay") else null
 			if item_display:
 				item_display.visible = false
 				print("DEBUG: ItemDisplay in Slot ", slot_index, " unsichtbar gemacht")
@@ -127,7 +262,7 @@ func _on_slot_pressed(slot_index: int):
 				print("DEBUG: ItemDisplay nicht gefunden in Slot ", slot_index)
 
 			# Verstecke das Label im Slot sofort
-			var label = slots[slot_index].get_node("CenterContainer/Panel/Label") if slots[slot_index].has_node("CenterContainer/Panel/Label") else null
+			var label = slot_node.get_node("CenterContainer/Panel/Label") if slot_node and slot_node.has_node("CenterContainer/Panel/Label") else null
 			if label:
 				label.visible = false
 				print("DEBUG: Label in Slot ", slot_index, " unsichtbar gemacht")
@@ -143,7 +278,7 @@ func _on_slot_pressed(slot_index: int):
 				var texture_size = dragging_sprite.texture.get_size()
 				dragging_sprite.scale = Vector2(64.0 / texture_size.x, 64.0 / texture_size.y)
 
-			dragging_slot_index = slot_index
+			dragging_slot_ref_index = slot_index
 
 			# Aktualisiere die Slots sofort
 			update_slots()  # Stelle sicher, dass das Inventar UI sofort aktualisiert wird
@@ -154,44 +289,41 @@ func _on_slot_released(slot_index: int):
 	if dragging_item:
 		if slot_index != -1:
 			# Wenn der Slot unter der Maus existiert, lege das Item dort ab
-			var target_slot = inv.slots[slot_index]
-			var source_slot = inv.slots[dragging_slot_index]
+			var target_ref = _get_slot_ref(slot_index)
+			var source_ref = _get_slot_ref(dragging_slot_ref_index)
+			var target_slot = _get_slot_data(target_ref)
+			var source_slot = _get_slot_data(source_ref)
 
-			if target_slot != source_slot:
-				# Tausch der Slots oder Stapeln der Items, wenn die Bedingungen zutreffen
-				if target_slot.item == source_slot.item and target_slot.amount < 64:
-					# Stapeln des Items, wenn der Ziel-Slot das gleiche Item enthält und Platz hat
-					var remaining_space = 64 - target_slot.amount
-					var amount_to_stack = min(remaining_space, source_slot.amount)
-					target_slot.amount += amount_to_stack
-					source_slot.amount -= amount_to_stack
-
-					# Wenn die Menge im Quell-Slot jetzt 0 ist, setze das Item auf null
-					if source_slot.amount == 0:
-						source_slot.item = null
+			if target_slot and source_slot and target_slot != source_slot:
+				if _is_equipment_slot(target_ref):
+					_handle_drop_to_equipment(source_ref, target_ref, source_slot, target_slot)
+				elif _is_equipment_slot(source_ref):
+					_handle_drop_from_equipment(source_ref, target_ref, source_slot, target_slot)
 				else:
-					# Items werden einfach getauscht
-					inv.swap_slots(dragging_slot_index, slot_index)
+					_handle_inventory_drop(source_slot, target_slot)
 
 		# Entferne das draggende Item, nachdem es abgelegt wurde
 		dragging_item.queue_free()
 		dragging_item = null
 		dragging_sprite = null
-		dragging_slot_index = -1
+		dragging_slot_ref_index = -1
 
 		update_slots()
 
-		# Stelle sicher, dass das Item im Quell-Slot wieder angezeigt wird, wenn es abgelegt wurde
-		var source_slot_ui = slots[dragging_slot_index].get_node("CenterContainer/Panel/ItemDisplay") if slots[dragging_slot_index].has_node("ItemTexture") else null
-		if source_slot_ui:
-			source_slot_ui.visible = true  # Stelle das ItemTexture im Quell-Slot wieder her
+		# Slots nach dem Ablegen neu zeichnen
 
 func _on_right_click(slot_index: int):
 	if not dragging_item:
 		return
-	
-	var source_slot = inv.slots[dragging_slot_index]
-	var target_slot = inv.slots[slot_index]
+
+	var source_ref = _get_slot_ref(dragging_slot_ref_index)
+	var target_ref = _get_slot_ref(slot_index)
+
+	if _is_equipment_slot(source_ref) or _is_equipment_slot(target_ref):
+		return
+
+	var source_slot = _get_slot_data(source_ref)
+	var target_slot = _get_slot_data(target_ref)
 	
 	# Sicherheitsprüfungen
 	if not source_slot.item or source_slot.amount <= 0:
@@ -247,7 +379,7 @@ func cleanup_dragging_item():
 	if dragging_item:
 		dragging_item.queue_free()
 		dragging_item = null
-	dragging_slot_index = -1
+	dragging_slot_ref_index = -1
 
 func update_dragging_item(item: InvItem):
 	if dragging_item:
@@ -286,7 +418,8 @@ func create_dragging_item(item: InvItem) -> Control:
 	
 # Slot unter der Maus ermitteln
 func get_slot_index_under_mouse() -> int:
-	for i in range(slots.size()):
-		if slots[i].get_global_rect().has_point(get_global_mouse_position()):
+	for i in range(slot_refs.size()):
+		var slot_node = slot_refs[i].get("node")
+		if slot_node and slot_node.get_global_rect().has_point(get_global_mouse_position()):
 			return i
 	return -1

--- a/InventorySystem/inv_ui.tscn
+++ b/InventorySystem/inv_ui.tscn
@@ -7,11 +7,11 @@
 
 [node name="InvUI" type="Control"]
 modulate = Color(1, 1, 1, 0.937255)
-custom_minimum_size = Vector2(208, 98)
+custom_minimum_size = Vector2(520, 220)
 layout_mode = 3
 anchors_preset = 0
-offset_right = 208.0
-offset_bottom = 98.0
+offset_right = 520.0
+offset_bottom = 220.0
 script = ExtResource("1_px203")
 
 [node name="NinePatchRect" type="NinePatchRect" parent="."]
@@ -148,3 +148,75 @@ layout_mode = 2
 
 [node name="Slot_hotbar9" parent="NinePatchRect/GridContainer" instance=ExtResource("4_6xbyo")]
 layout_mode = 2
+
+[node name="EquipmentPanel" type="NinePatchRect" parent="."]
+layout_mode = 0
+offset_left = 180.0
+offset_top = 0.0
+offset_right = 500.0
+offset_bottom = 210.0
+texture = ExtResource("2_1yy2w")
+patch_margin_left = 4
+patch_margin_top = 4
+patch_margin_right = 4
+patch_margin_bottom = 4
+
+[node name="EquipmentTitle" type="Label" parent="EquipmentPanel"]
+layout_mode = 0
+offset_left = 12.0
+offset_top = 8.0
+offset_right = 180.0
+offset_bottom = 28.0
+text = "Ausrüstung"
+
+[node name="EquipmentGrid" type="GridContainer" parent="EquipmentPanel"]
+layout_mode = 0
+offset_left = 12.0
+offset_top = 32.0
+offset_right = 308.0
+offset_bottom = 200.0
+columns = 2
+theme_override_constants/h_separation = 8
+theme_override_constants/v_separation = 6
+
+[node name="WeaponSlot" parent="EquipmentPanel/EquipmentGrid" instance=ExtResource("3_3kb3x")]
+layout_mode = 2
+
+[node name="WeaponLabel" type="Label" parent="EquipmentPanel/EquipmentGrid"]
+layout_mode = 2
+text = "Waffe"
+
+[node name="HeadSlot" parent="EquipmentPanel/EquipmentGrid" instance=ExtResource("3_3kb3x")]
+layout_mode = 2
+
+[node name="HeadLabel" type="Label" parent="EquipmentPanel/EquipmentGrid"]
+layout_mode = 2
+text = "Kopf"
+
+[node name="ChestSlot" parent="EquipmentPanel/EquipmentGrid" instance=ExtResource("3_3kb3x")]
+layout_mode = 2
+
+[node name="ChestLabel" type="Label" parent="EquipmentPanel/EquipmentGrid"]
+layout_mode = 2
+text = "Rüstung"
+
+[node name="BootsSlot" parent="EquipmentPanel/EquipmentGrid" instance=ExtResource("3_3kb3x")]
+layout_mode = 2
+
+[node name="BootsLabel" type="Label" parent="EquipmentPanel/EquipmentGrid"]
+layout_mode = 2
+text = "Stiefel"
+
+[node name="RingSlot" parent="EquipmentPanel/EquipmentGrid" instance=ExtResource("3_3kb3x")]
+layout_mode = 2
+
+[node name="RingLabel" type="Label" parent="EquipmentPanel/EquipmentGrid"]
+layout_mode = 2
+text = "Ring"
+
+[node name="AmuletSlot" parent="EquipmentPanel/EquipmentGrid" instance=ExtResource("3_3kb3x")]
+layout_mode = 2
+
+[node name="AmuletLabel" type="Label" parent="EquipmentPanel/EquipmentGrid"]
+layout_mode = 2
+text = "Amulett"

--- a/InventorySystem/inventory_item.gd
+++ b/InventorySystem/inventory_item.gd
@@ -4,6 +4,8 @@ class_name InvItem
 
 @export var name: String = ""
 @export var texture: Texture2D
+@export var is_equipment: bool = false
+@export var equip_slot: String = ""
 @export var health_bonus: float = 0 # in %
 @export var damage_bonus: float = 0 # in %
 @export var crit_chance_bonus: float = 0  # in % (z.B. 0.05 für +5%)

--- a/InventorySystem/items/bat_artefact.tres
+++ b/InventorySystem/items/bat_artefact.tres
@@ -7,6 +7,8 @@
 script = ExtResource("1_4tvji")
 name = "bat_artefact"
 texture = ExtResource("2_6oehd")
+is_equipment = true
+equip_slot = "weapon"
 health_bonus = 0.0
 damage_bonus = 0.5
 crit_chance_bonus = 0.1

--- a/InventorySystem/items/golem_heart.tres
+++ b/InventorySystem/items/golem_heart.tres
@@ -7,6 +7,8 @@
 script = ExtResource("1_wl6qs")
 name = "golem_heart"
 texture = ExtResource("2_i7chx")
+is_equipment = true
+equip_slot = "amulet"
 health_bonus = 0.5
 damage_bonus = 0.0
 crit_chance_bonus = 0.0

--- a/InventorySystem/playerinv.tres
+++ b/InventorySystem/playerinv.tres
@@ -147,6 +147,31 @@ amount = 0
 script = ExtResource("2_6ohk7")
 amount = 0
 
+[sub_resource type="Resource" id="Resource_equip_weapon"]
+script = ExtResource("2_6ohk7")
+amount = 0
+
+[sub_resource type="Resource" id="Resource_equip_head"]
+script = ExtResource("2_6ohk7")
+amount = 0
+
+[sub_resource type="Resource" id="Resource_equip_chest"]
+script = ExtResource("2_6ohk7")
+amount = 0
+
+[sub_resource type="Resource" id="Resource_equip_boots"]
+script = ExtResource("2_6ohk7")
+amount = 0
+
+[sub_resource type="Resource" id="Resource_equip_ring"]
+script = ExtResource("2_6ohk7")
+amount = 0
+
+[sub_resource type="Resource" id="Resource_equip_amulet"]
+script = ExtResource("2_6ohk7")
+amount = 0
+
 [resource]
 script = ExtResource("3_aofip")
 slots = Array[ExtResource("2_6ohk7")]([SubResource("Resource_wofib"), SubResource("Resource_8qtb1"), SubResource("Resource_md2q5"), SubResource("Resource_7sdct"), SubResource("Resource_pym4v"), SubResource("Resource_cx5pu"), SubResource("Resource_l7rge"), SubResource("Resource_uruh1"), SubResource("Resource_5a3s4"), SubResource("Resource_85662"), SubResource("Resource_ufr2e"), SubResource("Resource_mqjss"), SubResource("Resource_am8p3"), SubResource("Resource_1n154"), SubResource("Resource_u3iod"), SubResource("Resource_m8a06"), SubResource("Resource_fekb7"), SubResource("Resource_t0yyg"), SubResource("Resource_ypxov"), SubResource("Resource_5t2r3"), SubResource("Resource_w7kei"), SubResource("Resource_kxnt3"), SubResource("Resource_e5t13"), SubResource("Resource_q04di"), SubResource("Resource_kjmsf"), SubResource("Resource_e3376"), SubResource("Resource_2pj8t"), SubResource("Resource_yqjgc"), SubResource("Resource_82asr"), SubResource("Resource_icuqq"), SubResource("Resource_rtqfu"), SubResource("Resource_ayu21"), SubResource("Resource_1mdfy"), SubResource("Resource_sv7cg"), SubResource("Resource_akt5g"), SubResource("Resource_lgmc1")])
+equipment_slots = Array[ExtResource("2_6ohk7")]([SubResource("Resource_equip_weapon"), SubResource("Resource_equip_head"), SubResource("Resource_equip_chest"), SubResource("Resource_equip_boots"), SubResource("Resource_equip_ring"), SubResource("Resource_equip_amulet")])

--- a/Scenes/finale.tscn
+++ b/Scenes/finale.tscn
@@ -1,0 +1,109 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://Scripts/finale.gd" id="1_6f3y2"]
+[ext_resource type="Texture2D" path="res://Assets/MainMenu/background_sprite.png" id="2_3t1qn"]
+[ext_resource type="Texture2D" path="res://Assets/GUI/TextBox.png" id="3_d9l1o"]
+[ext_resource type="FontFile" path="res://Assets/GUI/Font/PixelatedEleganceRegular-ovyAA.ttf" id="4_2rj8k"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_2b34q"]
+texture = ExtResource("3_d9l1o")
+
+[node name="Finale" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_6f3y2")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="BackgroundSprite" type="Sprite2D" parent="CanvasLayer"]
+position = Vector2(964, 541)
+scale = Vector2(1, 1.04167)
+texture = ExtResource("2_3t1qn")
+hframes = 5
+vframes = 2
+
+[node name="TextPanel" type="Panel" parent="CanvasLayer"]
+custom_minimum_size = Vector2(700, 180)
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -350.0
+offset_top = -270.0
+offset_right = 350.0
+offset_bottom = -90.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_styles/panel = SubResource("StyleBoxTexture_2b34q")
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/TextPanel"]
+custom_minimum_size = Vector2(650, 120)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -325.0
+offset_top = -60.0
+offset_right = 325.0
+offset_bottom = 60.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 15
+
+[node name="StoryText" type="Label" parent="CanvasLayer/TextPanel/MarginContainer"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("4_2rj8k")
+theme_override_font_sizes/font_size = 20
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 1
+text = ""
+
+[node name="ContinueHint" type="Label" parent="CanvasLayer/TextPanel"]
+layout_mode = 0
+offset_left = 550.0
+offset_top = 16.0
+offset_right = 670.0
+offset_bottom = 40.0
+theme_override_fonts/font = ExtResource("4_2rj8k")
+theme_override_font_sizes/font_size = 18
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+text = "[E] Weiter"
+
+[node name="EndButtons" type="HBoxContainer" parent="CanvasLayer"]
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -240.0
+offset_top = -70.0
+offset_right = 240.0
+offset_bottom = -20.0
+alignment = 1
+
+[node name="ToCreditsButton" type="Button" parent="CanvasLayer/EndButtons"]
+custom_minimum_size = Vector2(200, 40)
+text = "Abspann"
+theme_override_fonts/font = ExtResource("4_2rj8k")
+theme_override_font_sizes/font_size = 18
+
+[node name="ToMenuButton" type="Button" parent="CanvasLayer/EndButtons"]
+custom_minimum_size = Vector2(200, 40)
+text = "Hauptmenü"
+theme_override_fonts/font = ExtResource("4_2rj8k")
+theme_override_font_sizes/font_size = 18
+
+[connection signal="pressed" from="CanvasLayer/EndButtons/ToCreditsButton" to="." method="_on_to_credits_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/EndButtons/ToMenuButton" to="." method="_on_to_menu_button_pressed"]

--- a/Scenes/level1.tscn
+++ b/Scenes/level1.tscn
@@ -476,7 +476,7 @@ level = "level0"
 
 [node name="Door2" parent="Background" instance=ExtResource("5_bs12r")]
 position = Vector2(754, 960)
-level = "Game"
+level = "finale"
 
 [node name="Spike4" parent="Background" instance=ExtResource("4_esggg")]
 position = Vector2(496, 807)

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -432,11 +432,16 @@ func _on_water_exited(body: Node):
 		is_in_water = false
 		#$SplashSound.play()
 
+func _get_bonus_slots() -> Array:
+	if inv and inv.equipment_slots.size() > 0:
+		return inv.equipment_slots
+	return inv.slots
+
 func update_crit_bonuses():
 	var total_crit_chance = base_crit_chance
 	var total_crit_damage = base_crit_multiplier
 	
-	for slot in inv.slots:
+	for slot in _get_bonus_slots():
 		if slot.item and slot.amount > 0:
 			total_crit_chance += slot.item.crit_chance_bonus * slot.amount
 			total_crit_damage += slot.item.crit_damage_bonus * slot.amount
@@ -447,7 +452,7 @@ func update_crit_bonuses():
 func update_damage_bonus():
 	var bonus = 1.0  # Startwert für Multiplikation
 
-	for slot in inv.slots:
+	for slot in _get_bonus_slots():
 		if slot.item and slot.amount > 0:  # Falls der Slot gültig ist und Items enthält
 			bonus += slot.item.damage_bonus * slot.amount  # Multipliziere mit Stack-Anzahl
 
@@ -456,7 +461,7 @@ func update_damage_bonus():
 
 func update_health_bonus():
 	var bonus = 1.0
-	for slot in inv.slots:
+	for slot in _get_bonus_slots():
 		if slot.item and slot.amount > 0:
 			bonus += slot.item.health_bonus * slot.amount
 

--- a/Scripts/finale.gd
+++ b/Scripts/finale.gd
@@ -1,0 +1,67 @@
+extends Control
+
+const LORE_LINES = [
+	"Die Luft hier ist warm und leuchtet wie flüssiges Sternenlicht.",
+	"Ich höre das Echo meines alten Namens... und den Ruf der Lumora.",
+	"Sie waren nie nur Lichtwesen. Sie sind Erinnerungen der Welt.",
+	"Der Schatten, der mich verschlang, wollte diese Erinnerungen brechen.",
+	"Doch in mir ist jetzt ein Kern aus reinem Glanz.",
+	"Ich war ein Mensch... und ich bin jetzt mehr als das.",
+	"Wenn ich dieses Herz berühre, kehrt der Fluss zurück.",
+	"Die Höhlen werden wieder atmen. Die Wälder werden wieder singen.",
+	"Und ich... werde Joey bleiben, egal welche Form ich trage."
+]
+
+var current_line := 0
+var ending_unlocked := false
+
+@onready var story_text: Label = $CanvasLayer/TextPanel/MarginContainer/StoryText
+@onready var continue_hint: Label = $CanvasLayer/TextPanel/ContinueHint
+@onready var credits_button: Button = $CanvasLayer/EndButtons/ToCreditsButton
+@onready var menu_button: Button = $CanvasLayer/EndButtons/ToMenuButton
+
+func _ready() -> void:
+	update_line()
+	credits_button.hide()
+	menu_button.hide()
+
+func _unhandled_input(event: InputEvent) -> void:
+	if ending_unlocked:
+		return
+	if event.is_action_pressed("Interact") or event.is_action_pressed("ui_accept"):
+		advance_story()
+
+func advance_story() -> void:
+	if current_line < LORE_LINES.size() - 1:
+		current_line += 1
+		update_line()
+	else:
+		unlock_ending()
+
+func update_line() -> void:
+	story_text.text = LORE_LINES[current_line]
+	continue_hint.text = "[E] Weiter"
+
+func unlock_ending() -> void:
+	ending_unlocked = true
+	continue_hint.text = "Danke fürs Spielen!"
+	credits_button.show()
+	menu_button.show()
+
+func _on_to_credits_button_pressed() -> void:
+	change_scene("res://Scenes/credits.tscn")
+
+func _on_to_menu_button_pressed() -> void:
+	change_scene("res://Scenes/main_menu.tscn")
+
+func change_scene(scene_path: String) -> void:
+	var target_scene = load(scene_path)
+	if target_scene == null:
+		push_error("Szene konnte nicht geladen werden: %s" % scene_path)
+		return
+	var scene_instance = target_scene.instantiate()
+	var current_scene = get_tree().current_scene
+	if current_scene:
+		current_scene.queue_free()
+	get_tree().root.add_child(scene_instance)
+	get_tree().current_scene = scene_instance

--- a/Scripts/game.gd
+++ b/Scripts/game.gd
@@ -17,6 +17,10 @@ var intro_lines = [
 	"Diese Höhle... sie strahlt eine seltsame Energie aus...",
 	"Ich spüre... hier liegt ein Geheimnis verborgen...",
 	"Vielleicht... vielleicht bin ich genau deshalb hier...",
+	"Die Steine flüstern... sie nennen es den Lumora-Kern.",
+	"Wenn der Kern bricht, verstummt das Licht in dieser Welt.",
+	"Und dieser Schatten... er hat nach mir gegriffen, um mich aufzuhalten.",
+	"Vielleicht bin ich nicht nur gefallen... vielleicht wurde ich erwählt.",
 	"Ich werde Antworten finden... egal was ich jetzt bin!"
 ]
 var current_line = 0

--- a/Scripts/inventory.gd
+++ b/Scripts/inventory.gd
@@ -5,22 +5,18 @@ class_name Inv
 signal update
 
 @export var slots: Array[InvSlot]
+@export var equipment_slots: Array[InvSlot] = []
 
 # Speichert das Inventar in eine Datei
 func save_inventory(file_path: String) -> void:
 	var file = FileAccess.open(file_path, FileAccess.WRITE)  # Benutze FileAccess statt File
 	if file:
 		# Serialisiert die Slots und Items in die Datei
-		var data = []
-		for slot in slots:
-			var slot_data = {}
-			if slot.item:
-				slot_data["item_name"] = slot.item.name
-				slot_data["amount"] = slot.amount
-			else:
-				slot_data["item_name"] = ""
-				slot_data["amount"] = 0
-			data.append(slot_data)
+		var data = {
+			"version": 1,
+			"inventory": _serialize_slots(slots),
+			"equipment": _serialize_slots(equipment_slots)
+		}
 		file.store_var(data)
 		file.close()
 		print("Inventar gespeichert in: %s" % file_path)
@@ -38,21 +34,25 @@ func load_inventory(file_path: String) -> void:
 		var data = file.get_var()
 		file.close()
 
-		if data == null or not data is Array:  # Überprüfung, ob `data` gültig ist
+		if data == null:
 			print("Fehler: Inventardatei enthält ungültige Daten.")
 			return
 
 		# Löscht bestehende Slots und lädt neue
-		for slot in slots:
-			slot.item = null
-			slot.amount = 0
+		_reset_slots(slots)
+		_reset_slots(equipment_slots)
 
-		for i in range(min(len(data), slots.size())):
-			var slot_data = data[i]
-			if slot_data["item_name"] != "":
-				var item = load_item(slot_data["item_name"])
-				slots[i].item = item
-				slots[i].amount = slot_data["amount"]
+		if data is Dictionary:
+			var inventory_data = data.get("inventory", [])
+			var equipment_data = data.get("equipment", [])
+			_load_slots_from_data(slots, inventory_data)
+			_load_slots_from_data(equipment_slots, equipment_data)
+		elif data is Array:
+			# Legacy-Format: Nur Inventar-Slots
+			_load_slots_from_data(slots, data)
+		else:
+			print("Fehler: Inventardatei enthält ungültige Daten.")
+			return
 
 		update.emit()
 		print("Inventar geladen von: %s" % file_path)
@@ -94,3 +94,30 @@ func swap_slots(index1: int, index2: int):
 	slots[index1] = slots[index2]
 	slots[index2] = temp
 	update.emit()
+
+func _serialize_slots(slot_array: Array[InvSlot]) -> Array:
+	var data = []
+	for slot in slot_array:
+		var slot_data = {}
+		if slot and slot.item:
+			slot_data["item_name"] = slot.item.name
+			slot_data["amount"] = slot.amount
+		else:
+			slot_data["item_name"] = ""
+			slot_data["amount"] = 0
+		data.append(slot_data)
+	return data
+
+func _reset_slots(slot_array: Array[InvSlot]) -> void:
+	for slot in slot_array:
+		if slot:
+			slot.item = null
+			slot.amount = 0
+
+func _load_slots_from_data(slot_array: Array[InvSlot], data: Array) -> void:
+	for i in range(min(len(data), slot_array.size())):
+		var slot_data = data[i]
+		if slot_data.get("item_name", "") != "":
+			var item = load_item(slot_data["item_name"])
+			slot_array[i].item = item
+			slot_array[i].amount = slot_data.get("amount", 0)


### PR DESCRIPTION
### Motivation
- Provide a proper equipment system and richer inventory UX so players can equip weapons/armor/rings/amulets and see their effects. 
- Persist equipped items and ensure player stat calculations read equipped gear rather than all inventory items. 
- Add an end-of-game finale scene and route the level exit to it, and extend the intro lore to better connect to the finale.

### Description
- Inventory/equipment: added `is_equipment` and `equip_slot` to `InventorySystem/inventory_item.gd`, added `equipment_slots` to `Scripts/inventory.gd` and to the `InventorySystem/playerinv.tres` resource, and updated save/load to persist an `equipment` array with backward-compatibility for legacy saves via `save_inventory`/`load_inventory` and helper functions (`_serialize_slots`, `_reset_slots`, `_load_slots_from_data`).
- UI & drag/drop: expanded `InventorySystem/inv_ui.tscn` with an `EquipmentPanel` and equipment slot nodes and rewrote `InventorySystem/inv_ui.gd` to build unified `slot_refs`, handle inventory vs equipment slots, validate equipment placement (`_can_place_in_equipment`), and implement equip-aware drag/drop logic and stacking/slot-swap helpers (`_handle_drop_to_equipment`, `_handle_drop_from_equipment`, `_handle_inventory_drop`, `_swap_slot_contents`).
- Tooltips & items: updated `InventorySystem/Tooltip.tscn` to display the equipment slot for gear; marked sample item resources as equipment (e.g. `InventorySystem/items/bat_artefact.tres` set `is_equipment = true, equip_slot = "weapon"`, and `golem_heart.tres` as `amulet`).
- Player stats: changed `Scenes/player.tscn` to compute bonuses from equipped slots via a new `_get_bonus_slots()` helper so health/damage/crit bonuses apply from gear rather than the whole inventory.
- Finale & routing: added `Scenes/finale.tscn` and `Scripts/finale.gd` to present sequential lore lines and end buttons (`ToCreditsButton`, `ToMenuButton`), updated `Scenes/level1.tscn` door `level` property to point to `finale`, and extended intro lore in `Scripts/game.gd` to better bridge to the finale.

### Testing
- No automated tests were executed for these changes (UI/content and save-format updates); changes were committed after local edits but no CI/unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739c3fd75c832d99046c163cf90451)